### PR TITLE
Change notify from class variable to instance variable

### DIFF
--- a/cyclicprng.py
+++ b/cyclicprng.py
@@ -40,7 +40,7 @@ class CyclicPRNG:
     cycle_start_time = None
     completed_cycle_count = 0
     consistent = False
-    notify = []
+    
 
     def __init__(
         self, cycle_size: int, consistent: bool = False, event_handler: callable = None
@@ -48,6 +48,7 @@ class CyclicPRNG:
         """
             Initialize PRNG that restarts after cycle_size calls
         """
+        self.notify = []
         self.size = cycle_size
         if self.size < 1:
             raise ValueError(


### PR DESCRIPTION
The current implementation of the CyclicPRNG class implements notify as a class variable.  This has the unintended outcome of the notify list attribute being shared across all instances of the class.  For example, using two instances A and B of differing cycle sizes triggers a call to all registered event handlers for both A and B when instance A restarts even if B is mid-cycle.

